### PR TITLE
fix: questionnaire answers would not be registered.

### DIFF
--- a/public/toAnswer.php
+++ b/public/toAnswer.php
@@ -148,17 +148,26 @@ if ($action == 'save_answer')
 						}
 						else
 							$answer->fk_choix = $answer_user;
+							$answer->fk_choix_col = 'DEFAULT';
 
-						$answer->save();
+						$result = $answer->save();
+						if ($result == -1) {
+							setEventMessage($answer->errors, 'errors');
+						}
 					}
 				} elseif (!is_array($content) && !empty($content))
 				{
 					$answer = new Answer($db);
 					$answer->fk_invitation_user = $fk_invitation;
 					$answer->fk_question = $fk_question;
+					$answer->fk_choix = 'DEFAULT';
+					$answer->fk_choix_col = 'DEFAULT';
 					$answer->value = $content;
 
-					$answer->save();
+					$result = $answer->save();
+					if ($result == -1) {
+						setEventMessage($answer->errors, 'errors');
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This due to the CommonObject::createCommon() method, at line 8391:
`$values[$k] = $this->quote($v, $value); // May return string 'NULL' if $value is null`

If fk_choix and fk_choix_col are not defined, they are set to NULL, which is forbidden.
This commit set them to the default value, which is 0.